### PR TITLE
Dynamic Item Details Page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/author/:id" element={<Author />} />
-        <Route path="/item-details" element={<ItemDetails />} />
+        <Route path="/item-details/:id" element={<ItemDetails />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/pages/Author.jsx
+++ b/src/pages/Author.jsx
@@ -38,6 +38,7 @@ const Author = () => {
   }
 
   useEffect(() => {
+    window.scrollTo(0, 0)
     fetchAuthor()
   }, [])
 
@@ -68,8 +69,8 @@ const Author = () => {
 
                           <i className="fa fa-check"></i>
                           <div className="profile_name">
-                            <div style={{ width: 'fit-content'}}>
-                              <h4 className="skelly" style={{margin: '3px 2px'}}>author name</h4>
+                            <div style={{ width: 'fit-content' }}>
+                              <h4 className="skelly" style={{ margin: '3px 2px' }}>author name</h4>
                               <span className="profile_username skelly" style={{ margin: '2px' }}>@authortag</span>
                               <span id="wallet" className="profile_wallet skelly" style={{ margin: '2px' }}>
                                 author blockchain address

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -29,7 +29,7 @@ const ItemDetails = () => {
       <div className="no-bottom no-top" id="content">
         <div id="top"></div>
         {
-          !!nft ?
+          !nft ?
             <section aria-label="section" className="mt90 sm-mt-0">
               <div className="container">
                 <div className="row">

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -29,73 +29,58 @@ const ItemDetails = () => {
       <div className="no-bottom no-top" id="content">
         <div id="top"></div>
         {
-          !nft ?
+          !!nft ?
             <section aria-label="section" className="mt90 sm-mt-0">
               <div className="container">
                 <div className="row">
                   <div className="col-md-6 text-center">
-                    <img
-                      src={nftImage}
-                      className="img-fluid img-rounded mb-sm-30 nft-image"
-                      alt=""
-                    />
+                    <div className="img-fluid img-rounded mb-sm-30 nft-image skelly"></div>
                   </div>
                   <div className="col-md-6">
                     <div className="item_info">
-                      <h2>Rainbow Style #194</h2>
+                      <h2 className="skelly">nft title nft title</h2>
 
                       <div className="item_info_counts">
-                        <div className="item_info_views">
-                          <i className="fa fa-eye"></i>
-                          100
+                        <div className="item_info_views skelly">
+                          <i className="fa fa-eye skelly"></i>
+                          views
                         </div>
-                        <div className="item_info_like">
-                          <i className="fa fa-heart"></i>
-                          74
+                        <div className="item_info_like skelly">
+                          <i className="fa fa-heart skelly"></i>
+                          likes
                         </div>
                       </div>
-                      <p>
+                      <p className="skelly">
                         doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
                         illo inventore veritatis et quasi architecto beatae vitae
                         dicta sunt explicabo.
                       </p>
                       <div className="d-flex flex-row">
                         <div className="mr40">
-                          <h6>Owner</h6>
+                          <h6 className="skelly">owner</h6>
                           <div className="item_author">
                             <div className="author_list_pp">
-                              <Link to="/author">
-                                <img className="lazy" src={AuthorImage} alt="" />
-                                <i className="fa fa-check"></i>
-                              </Link>
-                            </div>
-                            <div className="author_list_info">
-                              <Link to="/author">Monica Lucas</Link>
+                              <div className="skelly-pp skelly"></div>
                             </div>
                           </div>
+                          <div className="author_list_info skelly" style={{ marginLeft: '70px', height: '25px', marginBottom: '10px', marginTop: '20px' }}>owner</div>
                         </div>
-                        <div></div>
                       </div>
                       <div className="de_tab tab_simple">
                         <div className="de_tab_content">
-                          <h6>Creator</h6>
+                          <h6 className="skelly">creator</h6>
                           <div className="item_author">
                             <div className="author_list_pp">
-                              <Link to="/author">
-                                <img className="lazy" src={AuthorImage} alt="" />
-                                <i className="fa fa-check"></i>
-                              </Link>
-                            </div>
-                            <div className="author_list_info">
-                              <Link to="/author">Monica Lucas</Link>
+                              <div className="skelly-pp skelly"></div>
                             </div>
                           </div>
+                          <div className="author_list_info skelly" style={{ marginLeft: '70px', height: '25px', marginTop: '20px' }}>creator</div>
                         </div>
                         <div className="spacer-40"></div>
-                        <h6>Price</h6>
+                        <h6 className="skelly" style={{ margin: '16px 0' }}>Price</h6>
                         <div className="nft-item-price">
-                          <img src={EthImage} alt="" />
-                          <span>1.85</span>
+                          <span className="skelly" style={{ marginRight: '8px' }}>oo</span>
+                          <span className="skelly">price</span>
                         </div>
                       </div>
                     </div>
@@ -129,9 +114,7 @@ const ItemDetails = () => {
                         </div>
                       </div>
                       <p>
-                        Doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                        illo inventore veritatis et quasi architecto beatae vitae
-                        dicta sunt explicabo.
+                        {nft.description}
                       </p>
                       <div className="d-flex flex-row">
                         <div className="mr40">

--- a/src/pages/ItemDetails.jsx
+++ b/src/pages/ItemDetails.jsx
@@ -1,91 +1,183 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EthImage from "../images/ethereum.svg";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import AuthorImage from "../images/author_thumbnail.jpg";
 import nftImage from "../images/nftImage.jpg";
+import axios from "axios";
 
 const ItemDetails = () => {
+
+  const { id } = useParams()
+  const [nft, setNft] = useState()
+
+  async function fetchNFT() {
+
+    const url = 'https://us-central1-nft-cloud-functions.cloudfunctions.net/itemDetails?nftId=' + id
+    const response = await axios.get(url)
+
+    setNft(response.data)
+
+  }
+
   useEffect(() => {
     window.scrollTo(0, 0);
+    fetchNFT()
   }, []);
 
   return (
     <div id="wrapper">
       <div className="no-bottom no-top" id="content">
         <div id="top"></div>
-        <section aria-label="section" className="mt90 sm-mt-0">
-          <div className="container">
-            <div className="row">
-              <div className="col-md-6 text-center">
-                <img
-                  src={nftImage}
-                  className="img-fluid img-rounded mb-sm-30 nft-image"
-                  alt=""
-                />
-              </div>
-              <div className="col-md-6">
-                <div className="item_info">
-                  <h2>Rainbow Style #194</h2>
+        {
+          !nft ?
+            <section aria-label="section" className="mt90 sm-mt-0">
+              <div className="container">
+                <div className="row">
+                  <div className="col-md-6 text-center">
+                    <img
+                      src={nftImage}
+                      className="img-fluid img-rounded mb-sm-30 nft-image"
+                      alt=""
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <div className="item_info">
+                      <h2>Rainbow Style #194</h2>
 
-                  <div className="item_info_counts">
-                    <div className="item_info_views">
-                      <i className="fa fa-eye"></i>
-                      100
-                    </div>
-                    <div className="item_info_like">
-                      <i className="fa fa-heart"></i>
-                      74
-                    </div>
-                  </div>
-                  <p>
-                    doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
-                    illo inventore veritatis et quasi architecto beatae vitae
-                    dicta sunt explicabo.
-                  </p>
-                  <div className="d-flex flex-row">
-                    <div className="mr40">
-                      <h6>Owner</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                      <div className="item_info_counts">
+                        <div className="item_info_views">
+                          <i className="fa fa-eye"></i>
+                          100
                         </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                        <div className="item_info_like">
+                          <i className="fa fa-heart"></i>
+                          74
                         </div>
                       </div>
-                    </div>
-                    <div></div>
-                  </div>
-                  <div className="de_tab tab_simple">
-                    <div className="de_tab_content">
-                      <h6>Creator</h6>
-                      <div className="item_author">
-                        <div className="author_list_pp">
-                          <Link to="/author">
-                            <img className="lazy" src={AuthorImage} alt="" />
-                            <i className="fa fa-check"></i>
-                          </Link>
+                      <p>
+                        doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+                        illo inventore veritatis et quasi architecto beatae vitae
+                        dicta sunt explicabo.
+                      </p>
+                      <div className="d-flex flex-row">
+                        <div className="mr40">
+                          <h6>Owner</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to="/author">
+                                <img className="lazy" src={AuthorImage} alt="" />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to="/author">Monica Lucas</Link>
+                            </div>
+                          </div>
                         </div>
-                        <div className="author_list_info">
-                          <Link to="/author">Monica Lucas</Link>
+                        <div></div>
+                      </div>
+                      <div className="de_tab tab_simple">
+                        <div className="de_tab_content">
+                          <h6>Creator</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to="/author">
+                                <img className="lazy" src={AuthorImage} alt="" />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to="/author">Monica Lucas</Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="spacer-40"></div>
+                        <h6>Price</h6>
+                        <div className="nft-item-price">
+                          <img src={EthImage} alt="" />
+                          <span>1.85</span>
                         </div>
                       </div>
-                    </div>
-                    <div className="spacer-40"></div>
-                    <h6>Price</h6>
-                    <div className="nft-item-price">
-                      <img src={EthImage} alt="" />
-                      <span>1.85</span>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
-        </section>
+            </section>
+            :
+            <section aria-label="section" className="mt90 sm-mt-0">
+              <div className="container">
+                <div className="row">
+                  <div className="col-md-6 text-center">
+                    <img
+                      src={nft.nftImage}
+                      className="img-fluid img-rounded mb-sm-30 nft-image"
+                      alt=""
+                    />
+                  </div>
+                  <div className="col-md-6">
+                    <div className="item_info">
+                      <h2>{nft.title}</h2>
+
+                      <div className="item_info_counts">
+                        <div className="item_info_views">
+                          <i className="fa fa-eye"></i>
+                          {nft.views}
+                        </div>
+                        <div className="item_info_like">
+                          <i className="fa fa-heart"></i>
+                          {nft.likes}
+                        </div>
+                      </div>
+                      <p>
+                        Doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+                        illo inventore veritatis et quasi architecto beatae vitae
+                        dicta sunt explicabo.
+                      </p>
+                      <div className="d-flex flex-row">
+                        <div className="mr40">
+                          <h6>Owner</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to={`/author/${nft.ownerId}`}>
+                                <img className="lazy" src={nft.ownerImage} alt="" />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to={`/author/${nft.ownerId}`}>{nft.ownerName}</Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div></div>
+                      </div>
+                      <div className="de_tab tab_simple">
+                        <div className="de_tab_content">
+                          <h6>Creator</h6>
+                          <div className="item_author">
+                            <div className="author_list_pp">
+                              <Link to={`/author/${nft.creatorId}`}>
+                                <img className="lazy" src={nft.creatorImage} alt="" />
+                                <i className="fa fa-check"></i>
+                              </Link>
+                            </div>
+                            <div className="author_list_info">
+                              <Link to={`/author/${nft.creatorId}`}>{nft.creatorName}</Link>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="spacer-40"></div>
+                        <h6>Price</h6>
+                        <div className="nft-item-price">
+                          <img src={EthImage} alt="" />
+                          <span>{nft.price}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+        }
       </div>
     </div>
   );


### PR DESCRIPTION
**Task**
Implement fully dynamic and responsive NFT details page, displaying API fetched content, with skeleton loading state.

**How**
Pulled content on NFT from the API, with pre-load skeleton. Linked all NFT displays on the site to their item-details page.

Old static item-details page:
![image](https://github.com/user-attachments/assets/f2a5d252-00c0-4cd8-a7b6-b1898dbe16ec)

New dynamic page:
![image](https://github.com/user-attachments/assets/a0200ba9-a2c4-4220-b810-ae19e4ee4ff1)